### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -41,7 +41,7 @@ class Json extends Plugin
         $this->name = $this->getName();
 
         // Add in our Twig extensions
-        Craft::$app->view->twig->addExtension(new JsonTwigExtension());
+        Craft::$app->view->registerTwigExtension(new JsonTwigExtension());
 
         Craft::info(
             Craft::t(


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.